### PR TITLE
Add loader component for .OBJ and .MTL files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Learn about the entity-component system which A-Frame is based on.
 Third-party A-Frame components (of the entity-component system).
 
 - [aframe-component-boilerplate](https://github.com/ngokevin/aframe-component-boilerplate)
-- [aframe-layout](https://github.com/ngokevin/aframe-layout)
+- [aframe-layout-component](https://github.com/ngokevin/aframe-layout-component)
+- [aframe-obj-loader-component](https://github.com/donmccurdy/aframe-obj-loader-component)
 - [aframe-text-component](https://github.com/ngokevin/aframe-text-component)
 
 ### React


### PR DESCRIPTION
Adds a new loader for .OBJ and .MTL files, based on existing THREE.MTLLoader and THREE.OBJMTLLoader.

This is very similar to the existing obj/collada loader, and could also be merged with that ([example PR to aframe-core](https://github.com/donmccurdy/aframe-core/commit/35a9d56e21d4785ae85e9197b907b3d500ef8457)). Happy to submit that as a PR instead, but a new component seemed like a cleaner way to go for a couple reasons:

1. A .MTL file can't easily be used with the material component, because a single .MTL file may generate more than one THREE.Mesh*\<Type\>*Material instances. Possibly unintuitive for new users.
2. Based on https://github.com/aframevr/aframe-core/issues/532 it might make more sense to focus on newer formats in the default loader.
3. I'm not sure how common .OBJ/.MTL files are. That's the most useful of [Maya LT's export formats](https://knowledge.autodesk.com/support/maya-lt/learn-explore/caas/CloudHelp/cloudhelp/2015/ENU/MayaLT/files/GUID-3A6190CA-E296-4A10-9287-5AEE156DBA9D-htm.html), so it's just what I've been using.

(also updated reference to iframe-layout-component)

EDIT: Also relates to https://github.com/aframevr/aframe/issues/124