### PR TITLE
fix broken https mozvr.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A collection of awesome things regarding [A-Frame](https://github.com/aframevr/a
 Straight from the horse's mouth.
 
 - [Official Site](https://aframe.io)
-- [Team Site](https://mozvr.com)
+- [Team Site](http://mozvr.com)
 - [Examples](https://aframe.io/examples/)
 
 #### Repositories


### PR DESCRIPTION
when we get MozVR.com served from GitHub Pages instead of S3, `https` will work. until then :-1: 