### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Integration with existing tools, frameworks, and libraries.
 Tools built with or for A-Frame.
 
 - [WebVR Studio](http://webvrstudio.com/)
-- [Fader Editor](https://fader.vragments.com/)
+- [Fader Editor](https://getfader.com/)
 - [IdeaSpace VR](https://www.ideaspacevr.org/)
 - [Hologram](https://hologram.cool/)
 


### PR DESCRIPTION
Fader editor has been moved to a new domain from https://fader.vragments.com to https://getfader.com.